### PR TITLE
Removing the rating attribute from the product creation form.

### DIFF
--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -28,10 +28,6 @@
     <%= f.text_field :price %>
   </div>
   <div class="field">
-    <%= f.label :rating %><br>
-    <%= f.text_field :rating %>
-  </div>
-  <div class="field">
     <%= f.label :quantity %><br>
     <%= f.number_field :quantity %>
   </div>


### PR DESCRIPTION
In the product creation form, there was one input for the product rating, which does not make sense. This commit remove that from the form.