### PR TITLE
Limit the number of items for each product that are added to the cart

### DIFF
--- a/app/controllers/line_items_controller.rb
+++ b/app/controllers/line_items_controller.rb
@@ -48,16 +48,11 @@ class LineItemsController < ApplicationController
     @line_item.quantity += params[:delta].to_i
 
     respond_to do |format|
-#      if @line_item.update(line_item_params)
-#        format.html { redirect_to @line_item, notice: 'Line item was successfully updated.' }
-#        format.json { render :show, status: :ok, location: @line_item }
-#      else
-#        format.html { render :edit }
-#        format.json { render json: @line_item.errors, status: :unprocessable_entity }
-#      end
-
       if @line_item.quantity > 0 && @line_item.save
 	format.html { redirect_to store_url, notice: 'Line item was successfully updated.' }
+        format.json { render :show, status: :ok, location: @line_item }
+      elsif @line_item.quantity > @line_item.product.quantity
+        format.html { redirect_to store_url, notice: 'No more items available for this product.' }
         format.json { render :show, status: :ok, location: @line_item }
       else
         @line_item.destroy

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -36,6 +36,10 @@ class OrdersController < ApplicationController
 
     respond_to do |format|
       if @order.save
+        # Before deleting the cart, we need to update the quantity of the products
+        # related to the line items of this cart
+        update_product_count()
+
         Cart.destroy(session[:cart_id])
         session[:cart_id] = nil
 		
@@ -84,5 +88,12 @@ class OrdersController < ApplicationController
     # Never trust parameters from the scary internet, only allow the white list through.
     def order_params
       params.require(:order).permit(:name, :address, :email, :pay_type)
+    end
+
+    def update_product_count
+        @order.line_items.each do |item|
+        item.product.quantity -= item.quantity
+        item.product.save
+        end
     end
 end

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -3,9 +3,14 @@ class LineItem < ActiveRecord::Base
   belongs_to :product
   belongs_to :cart
 
+  validates :cart_id, presence: true
   validates :product_id, presence: true, numericality: {greater_than_or_equal_to: 1}
-  validates :quantity, presence: true, numericality: {greater_than_or_equal_to: 1}
+  validates :quantity, presence: true, numericality: {greater_than_or_equal_to: 1, less_than_or_equal_to: :product_quantity}
   def total_price
     product.price * quantity
+  end
+
+  def product_quantity
+      product.quantity
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -3,7 +3,7 @@ class Product < ActiveRecord::Base
   validates :title, :description, :image_url, :quantity, presence: true
   validates :price, numericality: {greater_than_or_equal_to: 0.01}
   validates :rating, allow_blank: true, numericality: {greater_than_or_equal_to: 0.0, less_than_or_equal_to: 5.0}
-  validates :quantity, numericality: {greater_than_or_equal_to: 1}
+  validates :quantity, numericality: {greater_than_or_equal_to: 0}
   validates :image_url, allow_blank: true, format: {
     with:    %r{\.(gif|jpg|png)\Z}i,
     message: 'must be a URL for GIF, JPG or PNG image.'

--- a/app/views/store/index.html.erb
+++ b/app/views/store/index.html.erb
@@ -15,7 +15,11 @@
           <span class="price">Price: <%= number_to_currency(product.price) %></span>
           <span class="quantity">Quantity: <%= sprintf("%d", product.quantity) %></span>
           <span class="rating">Rating: <%= sprintf("%0.01f", product.rating) %></span>
-          <%= button_to 'Add to Cart', line_items_path(product_id: product), remote: true  %>
+          <% if product.quantity > 0 %>
+            <%= button_to 'Add to Cart', line_items_path(product_id: product), remote: true %>
+          <% else %>
+            <%= button_to 'Product Unavailable', '.', remote: true, disabled: true %>
+          <% end %>
         </div>
       </div>
     <% end %>

--- a/test/models/cart_test.rb
+++ b/test/models/cart_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class CartTest < ActiveSupport::TestCase
   test "cart add products test" do
     product = Product.new(id: 1)
+    product.quantity = 1
     cart = Cart.new(id: 1)
     line_item = LineItem.new(product: product, cart: cart)
     line_item.product_id = product.id

--- a/test/models/line_item_test.rb
+++ b/test/models/line_item_test.rb
@@ -2,28 +2,20 @@ require 'test_helper'
  
 class LineItemTest < ActiveSupport::TestCase
    test "line item attributes must not be empty" do
-     line_item = LineItem.new
+     product = Product.new(id: 1)
+     product.quantity = 1
+     line_item = LineItem.new(product: product)
      assert line_item.invalid?
-     assert line_item.errors[:product_id].any?
-#     assert line_item.errors[:cart_id].any?
-   end
- 
-   test "line item product id must be positive" do
-     # First try valid line_item (has valid product_id)
-     product = Product.new( id: 1)
-     cart = Cart.new(id: 1)
-     line_item = LineItem.new(product: product, cart: cart)
-     line_item.product_id = product.id
-     assert line_item.valid?
- 
-     # Now change product_id to an invalid value
-     line_item.product_id = -1
-     assert line_item.invalid?
+     # we do not have a cart associated with this line_item
+     assert line_item.errors[:cart_id].any?
+     # but we do have a product associated with this line_item
+     assert line_item.errors[:product_id].none?
    end
  
    test "line item cart quantity must be positive" do
      # First try valid line_item (has valid cart_id)
      product = Product.new(id: 1)
+     product.quantity = 1
      cart = Cart.new(id: 1)
      line_item = LineItem.new(product: product, cart: cart)
      line_item.cart_id = cart.id

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -37,12 +37,7 @@ class ProductTest < ActiveSupport::TestCase
                           price:     1)
     product.quantity = -1
     assert product.invalid?
-    assert_equal ["must be greater than or equal to 1"],
-      product.errors[:quantity]
-
-    product.quantity = 0
-    assert product.invalid?
-    assert_equal ["must be greater than or equal to 1"], 
+    assert_equal ["must be greater than or equal to 0"],
       product.errors[:quantity]
 
     product.quantity = 1


### PR DESCRIPTION
Now you cannot freely add items from a specific product to your cart. Once you reach the product quantity limit, you won't be able to add more items for that product. Also, if a product quantity reaches 0, it will become unavailable.